### PR TITLE
Add GOC_QUIET environment variable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/jfrog/goc
 require (
 	github.com/codegangsta/cli v1.20.0
 	github.com/jfrog/gocmd v0.1.4
+	github.com/jfrog/jfrog-client-go v0.3.0
 	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
-	"github.com/jfrog/gocmd"
+	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/jfrog/gocmd"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 func main() {
@@ -35,6 +38,10 @@ func goCmd(c *cli.Context) error {
 	url := os.Getenv("GOC_GO_CENTER_URL")
 	if url == "" {
 		url = "https://gocenter.io/"
+	}
+	if os.Getenv("GOC_QUIET") != "" {
+		log.Logger.SetOutputWriter(ioutil.Discard)
+		log.Logger.SetStderrWriter(ioutil.Discard)
 	}
 	return gocmd.RunWithFallback(args, url)
 }


### PR DESCRIPTION
When using `goc` as a drop-in replacement for `go`, the following can happen:

```
../../go/pkg/mod/honnef.co/go/tools@v0.0.0-20190128043916-71123fcbb8fe/ssa/util.go:17:2: unknown import path "golang.org/x/tools/go/ast/astutil": unexpected status (https://gocenter.io/golang.org/x/tools/@v/v0.0.0-20190204173059-021ffbf1e960.zip): 404 Not Found
```

This should fix that, if not in the cleanest way.